### PR TITLE
Add support for TNUll to Types.typeToString()

### DIFF
--- a/src/thx/core/Types.hx
+++ b/src/thx/core/Types.hx
@@ -68,6 +68,7 @@ Returns a string representation of a `ValueType`.
 **/
   public static function typeToString(type : Type.ValueType) {
     return switch type {
+      case TNull:     "Null";
       case TInt:      "Int";
       case TFloat:    "Float";
       case TBool:     "Bool";


### PR DESCRIPTION
Otherwise it breaks `Dynamics.equals( null, null );` and possibly other things.

The only case it should throw on now is TUnknown