### PR TITLE
Save the contents of the original error

### DIFF
--- a/src/thx/core/Error.hx
+++ b/src/thx/core/Error.hx
@@ -2,6 +2,7 @@ package thx.core;
 
 import haxe.PosInfos;
 import haxe.CallStack;
+import thx.core.error.ErrorWrapper;
 
 /**
 Defines a generic Error type. When the target platform is JS, `Error` extends the native
@@ -16,7 +17,7 @@ If `err` is already an instance of `Error`, it is returned and nothing is create
   public static function fromDynamic(err : Dynamic, ?pos : PosInfos) : Error {
     if(Std.is(err, Error))
       return cast err;
-    return new Error(""+err, null, pos);
+    return new ErrorWrapper(""+err, err, null, pos);
   }
 
 #if !js

--- a/src/thx/core/error/ErrorWrapper.hx
+++ b/src/thx/core/error/ErrorWrapper.hx
@@ -1,0 +1,13 @@
+package thx.core.error;
+
+import haxe.PosInfos;
+import haxe.CallStack;
+
+class ErrorWrapper extends thx.core.Error {
+  public var innerError : Dynamic;
+  public function new(message : String, innerError : Dynamic, ?stack : Array<StackItem>, ?pos : PosInfos) {
+    super(message, stack, pos);
+
+    this.innerError = innerError;
+  }
+}


### PR DESCRIPTION
Since the original dynamic error may have had amazing, useful information, attach it to the inside of the thx error so that it isn’t lost forever.