### PR TITLE
Arrays.orderPluck and a few minor fixes

### DIFF
--- a/src/thx/core/Arrays.hx
+++ b/src/thx/core/Arrays.hx
@@ -346,6 +346,13 @@ It works the same as `Array.sort()` but doesn't change the original array and re
   }
 
 /**
+Uses the pluck strategy to order an array.  Returns an ordered copy of the Array, leaving the original unchanged.
+Arguments for pluck are `_0` and `_1`.
+**/
+  macro public static function orderPluck<T>(array : ExprOf<Array<T>>, expr : ExprOf<Int>)
+    return macro $e{array}.order(function(_0, _1) return $e{expr});
+
+/**
 The method works like a normal `Array.map()` but instead of passing a function that
 receives an item, you can pass an expression that defines how to access to a member
 of the item itself.
@@ -507,7 +514,7 @@ It returns a copy of the array with its elements randomly changed in position.
 /**
 Uses the plcuk strategy to sort an array. Arguments for pluck are `_0` and `_1`.
 **/
-  macro public static function sortPluck<T>(array : ExprOf<Array<T>>, expr : ExprOf<Bool>)
+  macro public static function sortPluck<T>(array : ExprOf<Array<T>>, expr : ExprOf<Int>)
     return macro $e{array}.sort(function(_0, _1) return $e{expr});
 
 /**

--- a/src/thx/core/Floats.hx
+++ b/src/thx/core/Floats.hx
@@ -61,7 +61,7 @@ and the opposite (additive inverse or `-max`) as the lower limit.
 It returns the comparison value (an integer number) between two `float` values.
 **/
   inline public static function compare(a : Float, b : Float) : Int
-    return a < b ? -1 : (b > a ? 1 : 0);
+    return a < b ? -1 : (a > b ? 1 : 0);
 
 /**
 Rounds a number down to the specified number of decimals.

--- a/test/thx/core/TestArrays.hx
+++ b/test/thx/core/TestArrays.hx
@@ -7,6 +7,7 @@ package thx.core;
 
 import utest.Assert;
 using thx.core.Arrays;
+using thx.core.Floats;
 
 class TestArrays {
   public function new() { }
@@ -98,6 +99,36 @@ class TestArrays {
 
   public function testCompactInt() {
     Assert.same([1, 0, 2], [null, 1, null, 0, 2].compact());
+  }
+
+  public function testOrder() {
+    var arr = [2,3,1];
+    Assert.same([1,2,3], arr.order(function(_0, _1) return _0 - _1));
+    Assert.same([2,3,1], arr);
+  }
+
+  public function testOrderPluck() {
+    var arr = [2,3,1];
+    Assert.same([1,2,3], arr.orderPluck(_0 - _1));
+    Assert.same([2,3,1], arr);
+  }
+
+  public function testOrderPluckObjectOfInt() {
+    var obj1 = { key: 1 };
+    var obj2 = { key: 2 };
+    var obj3 = { key: 3 };
+    var arr = [obj2, obj3, obj1];
+    Assert.same([obj1, obj2, obj3], arr.orderPluck(_0.key - _1.key));
+    Assert.same([obj2, obj3, obj1], arr);
+  }
+
+  public function testOrderPluckObjectOfFloat() {
+    var obj1 = { key: 1.0 };
+    var obj2 = { key: 2.0 };
+    var obj3 = { key: 3.0 };
+    var arr = [obj2, obj3, obj1];
+    Assert.same([obj1, obj2, obj3], arr.orderPluck(_0.key.compare(_1.key)));
+    Assert.same([obj2, obj3, obj1], arr);
   }
 
   public function testSortPluck() {

--- a/test/thx/core/TestFloats.hx
+++ b/test/thx/core/TestFloats.hx
@@ -34,6 +34,24 @@ class TestFloats {
     Assert.floatEquals( 0, Floats.clampSym( 0, 10));
   }
 
+  public function testCompare() {
+    Assert.equals(-1, (1.0).compare(2.0));
+    Assert.equals(-1, (1.0).compare(3.0));
+    Assert.equals(-1, (-1.0).compare(3.0));
+    Assert.equals(-1, (-2.0).compare(-1.0));
+    Assert.equals(-1, (-Math.PI).compare(Math.PI));
+
+    Assert.equals(0, (1.0).compare(1.0));
+    Assert.equals(0, (2.0).compare(2.0));
+    Assert.equals(0, (-2.0).compare(-2.0));
+    Assert.equals(0, (Math.PI).compare(Math.PI));
+
+    Assert.equals(1, (1.0).compare(-1.0));
+    Assert.equals(1, (2.0).compare(1.0));
+    Assert.equals(1, (-3.0).compare(-56.0));
+    Assert.equals(1, (Math.PI).compare(-Math.PI));
+  }
+
   public function testRound() {
     var value = 123.456;
     Assert.floatEquals(123.5, value.roundTo(1));


### PR DESCRIPTION
- Add Arrays.orderPluck (like sortPluck but returns sorted copy, rather
  than sorting in-place)
- Fix for Floats.compare