### PR TITLE
More object methods for accessing by path

### DIFF
--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -103,6 +103,26 @@ tuple is the field name and the right value (_1) is the field value.
     );
 
 /**
+Determines whether an object has fields represented by a string path.  The path
+can contain object keys and array indices separated by ".".
+
+E.g. { key1: { key2: [1, 2, 3] } }.hasPath("key1.key2.2") -> returns true
+**/
+  public static function hasPath(o : {}, path : String, ?nonNullValue : Bool = false) : Bool {
+    var paths = path.split(".");
+    var current : Dynamic = o;
+
+    for (currentPath in paths) {
+      if (Reflect.hasField(current, currentPath)) {
+        current = Reflect.field(current, currentPath);
+      } else {
+        return false;
+      }
+    }
+    return true;
+  }
+
+/**
 Gets a value from an object by a string path.  The path can contain object keys and array indices separated
 by ".".  Returns null for a path that does not exist.
 

--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -108,7 +108,7 @@ can contain object keys and array indices separated by ".".
 
 E.g. { key1: { key2: [1, 2, 3] } }.hasPath("key1.key2.2") -> returns true
 **/
-  public static function hasPath(o : {}, path : String, ?nonNullValue : Bool = false) : Bool {
+  public static function hasPath(o : {}, path : String) : Bool {
     var paths = path.split(".");
     var current : Dynamic = o;
 
@@ -124,7 +124,7 @@ E.g. { key1: { key2: [1, 2, 3] } }.hasPath("key1.key2.2") -> returns true
         return false;
       }
     }
-    return nonNullValue ? current != null : true;
+    return true;
   }
 
 /**
@@ -133,7 +133,7 @@ Like `hasPath`, but will return `false` for null values, even if the key exists.
 E.g. { key1 : { key2: null } }.hasPathValue("key1.key2") -> returns false
 **/
   public static function hasPathValue(o : {}, path : String) : Bool {
-    return hasPath(o, path, true);
+    return getPath(o, path) != null;
   }
 
 /**

--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -119,7 +119,16 @@ E.g. { key1: { key2: [1, 2, 3] } }.hasPath("key1.key2.2") -> returns true
         return false;
       }
     }
-    return true;
+    return nonNullValue ? current != null : true;
+  }
+
+/**
+Like `hasPath`, but will return `false` for null values, even if the key exists.
+
+E.g. { key1 : { key2: null } }.hasPathValue("key1.key2") -> returns false
+**/
+  public static function hasPathValue(o : {}, path : String) : Bool {
+    return hasPath(o, path, true);
   }
 
 /**
@@ -195,6 +204,8 @@ E.g. { key1: { key2: [1, 2, 3] } }.setPath("key1.key2.2", 4) -> returns { key1: 
 
 /**
 Delete an object's property, given a string path to that property.
+
+E.g. { foo : 'bar' }.removePath('foo') -> returns {}
 **/
   public static function removePath(o : {}, path : String) : {} {
     var paths = path.split(".");

--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -107,7 +107,7 @@ Gets a value from an object by a string path.  The path can contain object keys 
 by ".".  Returns null for a path that does not exist.
 
 E.g. { key1: { key2: [1, 2, 3] } }.getPath("key1.key2.2") -> returns 3
-*/
+**/
   public static function getPath(o : {}, path : String) : Dynamic {
     var paths = path.split(".");
     var current : Dynamic = o;
@@ -133,7 +133,7 @@ by ".".  Returns the original object, for optional chaining of other object meth
 Inner objects and arrays will be created as needed when traversing the path.
 
 E.g. { key1: { key2: [1, 2, 3] } }.setPath("key1.key2.2", 4) -> returns { key1: { key2: [ 1, 2, 4 ] } }
-*/
+**/
   public static function setPath<T>(o : {}, path : String, val : T) : {} {
     var paths = path.split(".");
     var current : Dynamic = o;
@@ -170,6 +170,29 @@ E.g. { key1: { key2: [1, 2, 3] } }.setPath("key1.key2.2", 4) -> returns { key1: 
     } else {
       Reflect.setField(current, p, val);
     }
+    return o;
+  }
+
+/**
+Delete an object's property, given a string path to that property.
+**/
+  public static function deletePath(o : {}, path : String) : {} {
+    var paths = path.split(".");
+
+    // the last item in the list of paths is the target field
+    var target = paths.pop();
+
+    // iterate over all remaining fields to find the sub-object containing
+    // the target field to be removed
+    try {
+      var sub = paths.reduce(function(existing, nextLayer) {
+        return Reflect.field(existing, nextLayer);
+      }, o);
+
+      if (null != sub)
+        Reflect.deleteField(sub, target);
+    } catch (e : Dynamic) { }
+
     return o;
   }
 }

--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -113,7 +113,12 @@ E.g. { key1: { key2: [1, 2, 3] } }.hasPath("key1.key2.2") -> returns true
     var current : Dynamic = o;
 
     for (currentPath in paths) {
-      if (Reflect.hasField(current, currentPath)) {
+      if(currentPath.isDigitsOnly()) {
+        var index = Std.parseInt(currentPath),
+            arr = Std.instance(current, Array);
+        if(null == arr || arr.length <= index) return false;
+        current = arr[index];
+      } else if (Reflect.hasField(current, currentPath)) {
         current = Reflect.field(current, currentPath);
       } else {
         return false;

--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -185,8 +185,15 @@ Delete an object's property, given a string path to that property.
     // iterate over all remaining fields to find the sub-object containing
     // the target field to be removed
     try {
-      var sub = paths.reduce(function(existing, nextLayer) {
-        return Reflect.field(existing, nextLayer);
+      var sub = paths.reduce(function(existing, nextPath) {
+
+        if (nextPath.isDigitsOnly()) {
+          var current : Dynamic = existing;
+          var index = Std.parseInt(nextPath);
+          return current[index];
+        } else {
+          return Reflect.field(existing, nextPath);
+        }
       }, o);
 
       if (null != sub)

--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -176,7 +176,7 @@ E.g. { key1: { key2: [1, 2, 3] } }.setPath("key1.key2.2", 4) -> returns { key1: 
 /**
 Delete an object's property, given a string path to that property.
 **/
-  public static function deletePath(o : {}, path : String) : {} {
+  public static function removePath(o : {}, path : String) : {} {
     var paths = path.split(".");
 
     // the last item in the list of paths is the target field

--- a/test/thx/TestObjects.hx
+++ b/test/thx/TestObjects.hx
@@ -30,6 +30,31 @@ class TestObjects {
     Assert.same([{ _0 : 'a', _1 : 'A'}, { _0 : 'b', _1 : 'B'}], tuples);
   }
 
+  public function testHasPath() {
+    var o = {
+      key1: {
+        key2: 123,
+        key3: "abc",
+        key4: [
+          "one",
+          "two"
+        ],
+        key5: [
+          { key6: "test1" },
+          { key6: "test2" },
+        ],
+        key6: null
+      }
+    };
+
+    Assert.isTrue(o.hasPath('key1.key2'));
+    Assert.isTrue(o.hasPath('key1.key4.1'));
+    Assert.isTrue(o.hasPath('key1.key6'));
+
+    Assert.isFalse(o.hasPath('key1.key4.2'));
+    Assert.isFalse(o.hasPath('key1.key7'));
+  }
+
   public function testGetPath() {
     var o = {
       key1: {

--- a/test/thx/TestObjects.hx
+++ b/test/thx/TestObjects.hx
@@ -55,6 +55,29 @@ class TestObjects {
     Assert.isFalse(o.hasPath('key1.key7'));
   }
 
+  public function testHasPathValue() {
+    var o = {
+      key1: {
+        key2: 123,
+        key3: "abc",
+        key4: [
+          "one",
+          "two",
+          null
+        ],
+        key5: [
+          { key6: "test1" },
+          { key6: "test2" },
+        ],
+        key6: null
+      }
+    };
+
+    Assert.isFalse(o.hasPathValue('key1.key6'));
+    Assert.isFalse(o.hasPathValue('key1.key4.2'));
+    Assert.isFalse(o.hasPathValue('key1.key7'));
+  }
+
   public function testGetPath() {
     var o = {
       key1: {

--- a/test/thx/TestObjects.hx
+++ b/test/thx/TestObjects.hx
@@ -82,11 +82,19 @@ class TestObjects {
         }
       }
     };
+    var arr = {
+      foo: [{}, {
+        bar: 'baz'
+      }]
+    };
 
     Assert.same({}, simple.removePath('foo'));
     Assert.same({}, simple);
     Assert.same(simple, simple.removePath('a.b.c.d'));
 
     Assert.same({ foo: { bar: { baz: "qux"}}}, nested.removePath('foo.bar.other'));
+
+    Assert.same(arr, arr.removePath('foo.0.bar'));
+    Assert.same({ foo: [{}, {}]}, arr.removePath('foo.1.bar'));
   }
 }

--- a/test/thx/TestObjects.hx
+++ b/test/thx/TestObjects.hx
@@ -72,7 +72,7 @@ class TestObjects {
     Assert.same({ key1: 123, newKey: "val" }, { key1: 123 }.setPath("newKey", "val"));
   }
 
-  public function testDeletePath() {
+  public function testRemovePath() {
     var simple = { foo: "bar" };
     var nested = {
       foo: {
@@ -83,10 +83,10 @@ class TestObjects {
       }
     };
 
-    Assert.same({}, simple.deletePath('foo'));
+    Assert.same({}, simple.removePath('foo'));
     Assert.same({}, simple);
-    Assert.same(simple, simple.deletePath('a.b.c.d'));
+    Assert.same(simple, simple.removePath('a.b.c.d'));
 
-    Assert.same({ foo: { bar: { baz: "qux"}}}, nested.deletePath('foo.bar.other'));
+    Assert.same({ foo: { bar: { baz: "qux"}}}, nested.removePath('foo.bar.other'));
   }
 }

--- a/test/thx/TestObjects.hx
+++ b/test/thx/TestObjects.hx
@@ -71,4 +71,22 @@ class TestObjects {
     Assert.same({ key1: { key2: [ 1, 55, 3 ] } }, { key1: { key2: [1, 2, 3] } }.setPath("key1.key2.1", 55));
     Assert.same({ key1: 123, newKey: "val" }, { key1: 123 }.setPath("newKey", "val"));
   }
+
+  public function testDeletePath() {
+    var simple = { foo: "bar" };
+    var nested = {
+      foo: {
+        bar: {
+          baz: "qux",
+          other: "other"
+        }
+      }
+    };
+
+    Assert.same({}, simple.deletePath('foo'));
+    Assert.same({}, simple);
+    Assert.same(simple, simple.deletePath('a.b.c.d'));
+
+    Assert.same({ foo: { bar: { baz: "qux"}}}, nested.deletePath('foo.bar.other'));
+  }
 }


### PR DESCRIPTION
- `hasPath` returns `true` or `false` depending on whether the object has a key given a string path
- `hasPathValue` is like `hasPath` but returns `false` if the value of the final field is `null`
- `removePath` deletes the field it fiends at the end of the path (and returns the modified object, or the original object if no matching field was found).