### PR TITLE
Update object merging with magic return types and new methods

### DIFF
--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -45,12 +45,36 @@ using `thx.Dynamics.compare`.
     return Reflect.fields(o);
 
 /**
-Copies the values from the fields of `from` to `to`. If `to` already contains those fields, then it replace
+Merges `first` and `second` using the `combine` strategy to return a merged object. The returned
+object is typed as an object containing all of the fields from both `first` and `second`.
+**/
+  macro public static function merge(first : ExprOf<{}>, second : ExprOf<{}>) {
+    return thx.macro.Objects.mergeImpl(first, second);
+  }
+
+/**
+Copies the values from the fields of `first` and `second` to a new object. If `first` and `second` contain
+fields with the same name, the returned object will use the fields from `second`. Both objects passed
+to this function will be unmodified.
+**/
+  public static function combine(first : {}, second : {}) : {} {
+    var to = {};
+    for(field in Reflect.fields(first)) {
+      Reflect.setField(to, field, Reflect.field(first, field));
+    }
+    for(field in Reflect.fields(second)) {
+      Reflect.setField(to, field, Reflect.field(second, field));
+    }
+    return to;
+  }
+
+/**
+Copies the values from the fields of `from` to `to`. If `to` already contains those fields, then it replaces
 those values with the return value of the function `replacef`.
 
 If not set, `replacef` always returns the value from the `from` object.
 **/
-  public static function merge(to : {}, from : {}, ?replacef : String -> Dynamic -> Dynamic -> Dynamic) : {} {
+  public static function assign(to : {}, from : {}, ?replacef : String -> Dynamic -> Dynamic -> Dynamic) : {} {
     if(null == replacef)
       replacef = function(field : String, oldv : Dynamic, newv : Dynamic) return newv;
     for(field in Reflect.fields(from)) {

--- a/src/thx/macro/BuildResource.hx
+++ b/src/thx/macro/BuildResource.hx
@@ -69,9 +69,9 @@ class BuildResource {
 	static function getResourceObject(cls : ClassType) {
 		var o = {},
 				prefix = resolvePrefix(cls.meta);
-		Objects.merge(o, getContentMeta(cls.meta, cls.module, prefix));
-		Objects.merge(o, getMatchingFile(cls.name, cls.module, formats, prefix));
-		Objects.merge(o, getContentFile(cls.meta, cls.module, prefix));
+		Objects.assign(o, getContentMeta(cls.meta, cls.module, prefix));
+		Objects.assign(o, getMatchingFile(cls.name, cls.module, formats, prefix));
+		Objects.assign(o, getContentFile(cls.meta, cls.module, prefix));
 		return o;
 	}
 
@@ -83,7 +83,7 @@ class BuildResource {
 			.map(function(v) return v.params)
 			.flatten()
 			.map(function(p) return ExprTools.getValue(p))
-			.map(function(n) Objects.merge(o, n));
+			.map(function(n) Objects.assign(o, n));
 		var path = thx.macro.Macros.getModuleDirectory(module);
 		resolveReferences(o, prefix, module, path);
 		return o;
@@ -130,7 +130,7 @@ class BuildResource {
 
 	static function getFromFiles(list : Array<{ file : String, format : String }>, module : String, prefix : String) {
 		var o = {};
-		list.map(function(item) Objects.merge(o, getFromFile(item.file, module, prefix, item.format, false)));
+		list.map(function(item) Objects.assign(o, getFromFile(item.file, module, prefix, item.format, false)));
 		return o;
 	}
 

--- a/src/thx/macro/Objects.hx
+++ b/src/thx/macro/Objects.hx
@@ -24,15 +24,8 @@ class Objects {
     var qn = parts.join('.');
     return TypeTools.toComplexType(TypeTools.follow(Context.getType(qn)));
   }
-  #end
 
-/**
-Copies the values from the fields of `from` to `to`. If `to` already contains those fields, then it replace
-those values with the return value of the function `replacef`.
-
-If not set, `replacef` always returns the value from the `from` object.
-**/
-  macro public static function merge(to : ExprOf<{}>, from : ExprOf<{}>, ?replacef : ExprOf<String -> Dynamic -> Dynamic -> Dynamic>) {
+  public static function mergeImpl(to : ExprOf<{}>, from : ExprOf<{}>) {
     var typeTo = TypeTools.toComplexType(Context.typeof(to));
     var typeFrom = TypeTools.toComplexType(Context.typeof(from));
     var arr = [];
@@ -72,6 +65,11 @@ If not set, `replacef` always returns the value from the `from` object.
     }
 
     var t : ComplexType = TAnonymous(arr);
-    return macro (cast thx.Objects.merge($e{to}, $e{from}, $e{replacef}) : $t);
+    return macro (cast thx.Objects.combine($e{to}, $e{from}) : $t);
+  }
+  #end
+
+  macro public static function merge(to : ExprOf<{}>, from : ExprOf<{}>) {
+    return mergeImpl(to, from);
   }
 }

--- a/src/thx/macro/Objects.hx
+++ b/src/thx/macro/Objects.hx
@@ -1,0 +1,77 @@
+package thx.macro;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+import haxe.macro.TypeTools;
+
+using thx.Arrays;
+
+class Objects {
+
+  static function overwriteFieldsInType(fields : Array<Field>, type : Array<Field>) {
+    fields.map(function (field) {
+      type.extract(function (fvar) return fvar.name == field.name);
+      type.push(field);
+    });
+  }
+
+  #if macro
+  static function getTypeFromPath(name : String, pack : Array<String>, ?sub : String) {
+    var parts = pack.concat([name]);
+    if (null != sub)
+      parts.push(sub);
+    var qn = parts.join('.');
+    return TypeTools.toComplexType(TypeTools.follow(Context.getType(qn)));
+  }
+  #end
+
+/**
+Copies the values from the fields of `from` to `to`. If `to` already contains those fields, then it replace
+those values with the return value of the function `replacef`.
+
+If not set, `replacef` always returns the value from the `from` object.
+**/
+  macro public static function merge(to : ExprOf<{}>, from : ExprOf<{}>, ?replacef : ExprOf<String -> Dynamic -> Dynamic -> Dynamic>) {
+    var typeTo = TypeTools.toComplexType(Context.typeof(to));
+    var typeFrom = TypeTools.toComplexType(Context.typeof(from));
+    var arr = [];
+
+    switch typeTo {
+    case TAnonymous(fields):
+        arr = arr.concat(fields);
+      case TPath({name : name, pack : pack, sub : sub}):
+        var type = getTypeFromPath(name, pack, sub);
+
+        switch type {
+          case TAnonymous(fields):
+            arr = arr.concat(fields);
+          case _:
+            Context.error('Field `to` cannot be parsed for merge', to.pos);
+        }
+
+      case _:
+        trace(typeTo);
+        Context.error('Field `to` cannot use this expression for merge', to.pos);
+    }
+
+    switch typeFrom {
+      case TAnonymous(fields):
+        overwriteFieldsInType(fields, arr);
+      case TPath({name : name, pack : pack, sub : sub}):
+        var type = getTypeFromPath(name, pack, sub);
+        switch type {
+          case TAnonymous(fields):
+            overwriteFieldsInType(fields, arr);
+          case _:
+            Context.error('Field `from` cannot be parsed for merge', from.pos);
+        }
+      case _:
+        trace(typeFrom);
+        Context.error('Field `from` cannot use this expression for merge', from.pos);
+    }
+
+    var t : ComplexType = TAnonymous(arr);
+    return macro (cast thx.Objects.merge($e{to}, $e{from}, $e{replacef}) : $t);
+  }
+}

--- a/test/thx/TestObjects.hx
+++ b/test/thx/TestObjects.hx
@@ -35,9 +35,9 @@ class TestObjects {
 
     Assert.same([{ _0 : 'a', _1 : 'A'}, { _0 : 'b', _1 : 'B'}], tuples);
   }
-  public function testMergeMacro() {
+  public function testAssign() {
     var o = {'name' : 'Franco', age : 19};
-    var out = thx.macro.Objects.merge(o, { 'foo': 'bar', 'name' : 'Michael', 'age' : 'Two'});
+    var out : Dynamic = thx.Objects.assign(o, { 'foo': 'bar', 'name' : 'Michael', 'age' : 'Two'});
 
     Assert.same("Michael", out.name);
     Assert.same("Two", out.age);
@@ -48,7 +48,17 @@ class TestObjects {
     }
   }
 
-  public function testMergeMacroWithTypedef() {
+  public function testCombine() {
+    var o = {'name' : 'Franco', age : 19};
+    var out : Dynamic = thx.Objects.combine(o, { 'foo': 'bar', 'name' : 'Michael', 'age' : 'Two'});
+
+    Assert.same("Michael", out.name);
+    Assert.same("Two", out.age);
+    Assert.same("bar", out.foo);
+    Assert.same("Franco", o.name);
+  }
+
+  public function testMergeWithTypedef() {
     var to : SpecialObject = {
           bar : "qux"
         },
@@ -57,7 +67,7 @@ class TestObjects {
           extra : "field"
         };
 
-    var merged : SpecialObject = thx.macro.Objects.merge(to, from);
+    var merged : SpecialObject = thx.Objects.merge(to, from);
 
     Assert.same(merged.foo, from.foo);
     Assert.same(merged.bar, to.bar);

--- a/test/thx/TestObjects.hx
+++ b/test/thx/TestObjects.hx
@@ -3,6 +3,11 @@ package thx;
 import utest.Assert;
 using thx.Objects;
 
+typedef SpecialObject = {
+  ?foo : String,
+  ?bar : String
+};
+
 class TestObjects {
   public function new() { }
 
@@ -29,6 +34,34 @@ class TestObjects {
     tuples.sort(function(a, b) return Strings.compare(a._0, b._0));
 
     Assert.same([{ _0 : 'a', _1 : 'A'}, { _0 : 'b', _1 : 'B'}], tuples);
+  }
+  public function testMergeMacro() {
+    var o = {'name' : 'Franco', age : 19};
+    var out = thx.macro.Objects.merge(o, { 'foo': 'bar', 'name' : 'Michael', 'age' : 'Two'});
+
+    Assert.same("Michael", out.name);
+    Assert.same("Two", out.age);
+    Assert.same("bar", out.foo);
+
+    for (field in Reflect.fields(out)) {
+      Assert.same(Reflect.field(out, field), Reflect.field(o, field));
+    }
+  }
+
+  public function testMergeMacroWithTypedef() {
+    var to : SpecialObject = {
+          bar : "qux"
+        },
+        from = {
+          foo : "baz",
+          extra : "field"
+        };
+
+    var merged : SpecialObject = thx.macro.Objects.merge(to, from);
+
+    Assert.same(merged.foo, from.foo);
+    Assert.same(merged.bar, to.bar);
+    Assert.same(Reflect.field(merged, 'extra'), 'field');
   }
 
   public function testHasPath() {


### PR DESCRIPTION
- The old `merge` is now called `assign`
- `combine` leaves both objects untouched, and merges their properties into a new object that is returned
- The new `merge` uses `combine`, and sets the return type to an object with all of the fields from both objects (making it suitable for merging objects that conform to a `typedef`)