### PR TITLE
Arrays.containsAll(a, e) returns true if all elements in e are found in a

### DIFF
--- a/src/Thx.hx
+++ b/src/Thx.hx
@@ -58,7 +58,6 @@ typedef Types = thx.Types;
 typedef Url = thx.Url;
 typedef Uuid = thx.Uuid;
 typedef Weekday = thx.Weekday;
-
 typedef AbstractMethod = thx.error.AbstractMethod;
 typedef NotImplemented = thx.error.NotImplemented;
 typedef NullArgument = thx.error.NullArgument;

--- a/src/thx/Arrays.hx
+++ b/src/thx/Arrays.hx
@@ -130,6 +130,18 @@ An optional equality function can be passed as the last argument. If not provide
   }
 
 /**
+Returns `true` if all elements in `elements` are found in the array.
+
+An optional equality function can be passed as the last argument. If not provided, strict equality is adopted.
+**/
+ public static function containsAll<T>(array : Array<T>, elements : Iterable<T>, ?eq : T -> T -> Bool) : Bool {
+  for (el in elements) {
+    if (!contains(array, el, eq)) return false;
+  }
+  return true;
+ }
+
+/**
 Returns `true` if any element in `elements` is found in the array.
 
 An optional equality function can be passed as the last argument. If not provided, strict equality is adopted.

--- a/test/thx/TestArrays.hx
+++ b/test/thx/TestArrays.hx
@@ -155,6 +155,21 @@ class TestArrays {
   }
 #end
 
+  public function testContains() {
+    Assert.isTrue([1, 2, 3].contains(2));
+    Assert.isFalse([1, 2, 3].contains(4));
+  }
+  
+  public function testContainsAll() {
+    Assert.isTrue([1, 2, 3].containsAll([3, 1, 2]));
+    Assert.isFalse([1, 2, 3].containsAll([3, 1, 2, 4]));
+  }
+  
+  public function testContainsAny() {
+    Assert.isTrue([1, 2, 3].containsAny([2, 3, 4]));
+    Assert.isFalse([1, 2, 3].containsAny([4, 5, 6]));
+  }
+
   public function testCount() {
     var arr = [2,3,2,1,4,2,3],
         map = arr.count();


### PR DESCRIPTION
I noticed there was containsAny, but no containsAll. I looked around for a bit to make sure I wasn't overlooking another already existing function, and I think I'm good. What's more, tests for all of the contains methods don't exist so I made them.

Is there some way to exclude my merge commits from this? :/