### PR TITLE
Add minimal example of Haxe compiler error.

### DIFF
--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -32,6 +32,7 @@ class TestAll {
     runner.addCase(new thx.TestMaps());
     runner.addCase(new thx.TestNulls());
     runner.addCase(new thx.TestObjects());
+    runner.addCase(new thx.TestOptions());
     runner.addCase(new thx.TestPath());
     runner.addCase(new thx.TestRational());
     runner.addCase(new thx.TestQueryString());

--- a/test/thx/TestOptions.hx
+++ b/test/thx/TestOptions.hx
@@ -1,0 +1,19 @@
+package thx;
+
+import utest.Assert;
+import thx.Tuple;
+using thx.Functions;
+using thx.Floats;
+import thx.Options.*;
+
+import haxe.ds.Option;
+
+class TestOptions {
+  public function new() { }
+
+  public function testHaxeCompilerError() {
+    Assert.same(Some(new Tuple2("a", "b")), ap2(Tuple2.new, Some("a"), Some("b")));
+
+  }
+}
+


### PR DESCRIPTION
This error results from using an abstract constructor as a function
argument.