### PR TITLE
Adds 'fmap' to Iterators and Iterables.

### DIFF
--- a/src/thx/AnonymousMap.hx
+++ b/src/thx/AnonymousMap.hx
@@ -71,7 +71,7 @@ It returns an iterator of strings containing all the field keys in the object.
 It returns an iterator of values in the object.
 **/
   public function iterator() : Iterator<V>
-    return keys().map(function(k) return Reflect.field(o, k)).iterator();
+    return keys().fmap(Reflect.field.bind(o, _));
 
 /**
 It returns a string representation of the object.

--- a/src/thx/Arrays.hx
+++ b/src/thx/Arrays.hx
@@ -425,16 +425,19 @@ In case you have to use a type that is not supported by `@:generic`, please use 
   @:generic
   public static function groupBy<TKey, TValue>(arr : ReadonlyArray<TValue>, resolver : TValue -> TKey) : Map<TKey, Array<TValue>> {
     var map : Map<TKey, Array<TValue>> = new Map<TKey, Array<TValue>>();
-    arr.map(function(v : TValue) {
+
+    for (i in 0...arr.length) {
+      var v = arr[i];
       var key : TKey = resolver(v),
-          arr : Array<TValue> = map.get(key);
-      if(null == arr) {
-        arr = [v];
-        map.set(key, arr);
+          acc : Array<TValue> = map.get(key);
+
+      if(null == acc) {
+        map.set(key, [v]);
       } else {
-        arr.push(v);
+        acc.push(v);
       }
-    });
+    };
+
     return map;
   }
 
@@ -444,16 +447,18 @@ In case you have to use a type that is not supported by `@:generic`, please use 
   Groups are appended to the passed map.
   **/
   public static function groupByAppend<TKey, TValue>(arr : ReadonlyArray<TValue>, resolver : TValue -> TKey, map : Map<TKey, Array<TValue>>) : Map<TKey, Array<TValue>> {
-    arr.map(function(v : TValue) {
+    for (i in 0...arr.length) {
+      var v = arr[i];
       var key : TKey = resolver(v),
-          arr : Array<TValue> = map.get(key);
-      if(null == arr) {
-        arr = [v];
-        map.set(key, arr);
+          acc : Array<TValue> = map.get(key);
+
+      if (null == acc) {
+        map.set(key, [v]);
       } else {
-        arr.push(v);
+        acc.push(v);
       }
-    });
+    }
+
     return map;
   }
 #end
@@ -606,9 +611,9 @@ It applies a function against an accumulator and each value of the array (from l
   public static inline function foldLeft<A, B>(array: ReadonlyArray<A>, init: B, f: B -> A -> B): B
     return reduce(array, f, init);
 
-/**
- * Fold by mapping the contained values into some monoidal type and reducing with that monoid.
- */
+  /**
+   * Fold by mapping the contained values into some monoidal type and reducing with that monoid.
+   */
   public static function foldMap<A, B>(array: ReadonlyArray<A>, f: A -> B, m: Monoid<B>): B
     return foldLeft(array.map(f), m.zero, m.append);
 

--- a/src/thx/Arrays.hx
+++ b/src/thx/Arrays.hx
@@ -607,6 +607,12 @@ It applies a function against an accumulator and each value of the array (from l
     return reduce(array, f, init);
 
 /**
+ * Fold by mapping the contained values into some monoidal type and reducing with that monoid.
+ */
+  public static function foldMap<A, B>(array: ReadonlyArray<A>, f: A -> B, m: Monoid<B>): B
+    return foldLeft(array.map(f), m.zero, m.append);
+
+/**
 Resizes an array of `T` to an arbitrary length by adding more elements to its end
 or by removing extra elements.
 

--- a/src/thx/Iterables.hx
+++ b/src/thx/Iterables.hx
@@ -109,11 +109,23 @@ Refer to `Array.map`.
   inline public static function map<T, S>(it : Iterable<T>, f : T -> S) : Array<S>
     return Iterators.map(it.iterator(), f);
 
+  /**
+   * A proper Functor-like map function that preverses iterable structure.
+   */
+  inline public static function fmap<T, S>(it : Iterable<T>, f : T -> S) : Iterable<S>
+    return { iterator: function() return Iterators.fmap(it.iterator(), f) };
+
 /**
 Refer to `thx.Arrays.mapi`.
 **/
   inline public static function mapi<T, S>(it : Iterable<T>, f : T -> Int -> S) : Array<S>
     return Iterators.mapi(it.iterator(), f);
+
+  /**
+   * A proper Functor-like mapi function that preverses iterable structure, with index information.
+   */
+  inline public static function fmapi<T, S>(it : Iterable<T>, f : T -> Int -> S) : Iterable<S>
+    return { iterator: function() return Iterators.fmapi(it.iterator(), f) };
 
 /**
 Refer to `thx.Arrays.order`.

--- a/src/thx/Iterators.hx
+++ b/src/thx/Iterators.hx
@@ -156,6 +156,27 @@ Refer to `Array.map`.
   }
 
 /**
+Effectful traversal. Use this instead of .map if producing side-effects.
+This method consumes the original iterator.
+*/
+  public static function forEach<A>(it: Iterator<A>, proc: A -> Void): Void {
+    while (it.hasNext()) {
+      proc(it.next());
+    }
+  }
+
+/**
+ * Fold by mapping the contained values into some monoidal type and reducing with that monoid.
+ * FIXME: when map is fixed to return an Iterator, this could use reduce without constructing an intermediate
+ * data structure; for now it is inefficient and so must be implemented manually.
+ */
+  public static function foldMap<A, B>(it: Iterator<A>, f: A -> B, m: Monoid<B>): B {
+    var acc = m.zero;
+    for (v in it) acc = m.append(acc, f(v));
+    return acc;
+  }
+
+/**
 Refer to `thx.Arrays.mapi`.
 **/
   public static function mapi<T, S>(it : Iterator<T>, f : T -> Int -> S) : Array<S> {

--- a/src/thx/Monoid.hx
+++ b/src/thx/Monoid.hx
@@ -14,6 +14,6 @@ abstract Monoid<A> (MonoidImpl<A>) from MonoidImpl<A> {
   public var zero(get, never): A;
   function get_zero() return this.zero;
 
-  inline public function append(a0: A, a1: A): A
+  public function append(a0: A, a1: A): A
     return this.append(a0, a1);
 }

--- a/src/thx/Options.hx
+++ b/src/thx/Options.hx
@@ -94,6 +94,12 @@ wrapped in another Option.
     };
 
 /**
+ * Fold by mapping the contained value into some monoidal type and reducing with that monoid.
+ */
+  public static function foldMap<A, B>(option: Option<A>, f: A -> B, m: Monoid<B>): B
+    return foldLeft(map(option, f), m.zero, m.append);
+
+/**
 `filter` returns the current value if any contained value matches the predicate, None otherwise.
 **/
   public static function filter<A>(option: Option<A>, f: A -> Bool): Option<A>

--- a/src/thx/Ord.hx
+++ b/src/thx/Ord.hx
@@ -25,22 +25,22 @@ enum OrderingImpl {
 
 @:callable
 abstract Ord<A> (A -> A -> Ordering) from A -> A -> Ordering to A -> A -> Ordering {
-  inline public function order(a0: A, a1: A): Ordering
+  public function order(a0: A, a1: A): Ordering
     return this(a0, a1);
 
-  inline public function max(a0: A, a1: A): A
+  public function max(a0: A, a1: A): A
     return switch this(a0, a1) {
       case LT | EQ: a1;
       case GT: a0;
     };
 
-  inline public function min(a0: A, a1: A): A
+  public function min(a0: A, a1: A): A
     return switch this(a0, a1) {
       case LT | EQ: a0;
       case GT: a1;
     };
 
-  inline public function equal(a0: A, a1: A): Bool
+  public function equal(a0: A, a1: A): Bool
     return this(a0, a1) == EQ;
 
   public function contramap<B>(f: B -> A): Ord<B>

--- a/src/thx/QueryString.hx
+++ b/src/thx/QueryString.hx
@@ -20,21 +20,22 @@ abstract QueryString(Map<String, QueryStringValue>) from Map<String, QueryString
     return new Map();
 
   public static function parseWithSymbols(s : String, separator : String, assignment : String, ?decodeURIComponent : String -> String) : QueryString {
-    var qs : QueryString = new Map();
-    if(null == s)
-      return qs;
-    if(null == decodeURIComponent)
-      decodeURIComponent = QueryString.decodeURIComponent;
-    if(s.startsWith("?") || s.startsWith("#"))
-      s = s.substring(1);
-    s = s.ltrim();
-    s.split(separator)
-      .map(function(v) {
-        var parts = v.split(assignment);
-        if(parts[0] == "") return;
-        qs.add(decodeURIComponent(parts[0]), null == parts[1] ? null : decodeURIComponent(parts[1]));
-      });
-    return qs;
+    return if (null == s) {
+      new Map();
+    } else {
+      if(null == decodeURIComponent)
+        decodeURIComponent = QueryString.decodeURIComponent;
+      if(s.startsWith("?") || s.startsWith("#"))
+        s = s.substring(1);
+      s = s.ltrim();
+      s.split(separator).reduce(
+        function(qs: QueryString, v: String) {
+          var parts = v.split(assignment);
+          if (parts[0] != "") qs.add(decodeURIComponent(parts[0]), null == parts[1] ? null : decodeURIComponent(parts[1]));
+          return qs;
+        }, new Map() 
+      );
+    }
   }
 
   @:from inline public static function parse(s : String) : QueryString
@@ -54,17 +55,16 @@ abstract QueryString(Map<String, QueryStringValue>) from Map<String, QueryString
   }
 
   @:to public function toObject() : {} {
-    var o : Dynamic = {};
-    this.keys().map(function(key) {
-        var v : Array<String> = this.get(key);
-        if(v.length == 0)
-          Reflect.setField(o, key, null);
-        else if(v.length == 1)
-          Reflect.setField(o, key, v[0]);
-        else
-          Reflect.setField(o, key, v);
-      });
-    return o;
+    return this.keys().reduce(function(o: Dynamic, key: String) {
+      var v : Array<String> = this.get(key);
+      if(v.length == 0)
+        Reflect.setField(o, key, null);
+      else if(v.length == 1)
+        Reflect.setField(o, key, v[0]);
+      else
+        Reflect.setField(o, key, v);
+      return o;
+    }, {});
   }
 
   inline public function isEmpty() : Bool

--- a/src/thx/Validation.hx
+++ b/src/thx/Validation.hx
@@ -117,3 +117,9 @@ abstract Validation<E, A> (Either<E, A>) from Either<E, A> {
       s: Semigroup<X>): Validation<X, I>
     return v8.ap(val7(f.curry(), v1, v2, v3, v4, v5, v6, v7, s), s);
 }
+
+class ValidationExtensions {
+  public static inline function leftMapNel<E, E0, A>(n: VNel<E, A>, f: E -> E0): VNel<E0, A>
+    return n.leftMap(function(n) return n.map(f));
+}
+

--- a/src/thx/Validation.hx
+++ b/src/thx/Validation.hx
@@ -48,6 +48,18 @@ abstract Validation<E, A> (Either<E, A>) from Either<E, A> {
   inline public function map<B>(f: A -> B): Validation<E, B>
     return ap(Right(f), function(e1: E, e2: E) { throw "Unreachable"; });
 
+  public function foldLeft<B>(b: B, f: B -> A -> B): B
+    return switch this {
+      case Left(_): b;
+      case Right(a): f(b, a);
+    };
+
+/**
+ * Fold by mapping the contained value into some monoidal type and reducing with that monoid.
+ */
+  public function foldMap<B>(f: A -> B, m: Monoid<B>): B
+    return (map(f): Validation<E, B>).foldLeft(m.zero, m.append);
+
   public function ap<B>(v: Validation<E, A -> B>, s: Semigroup<E>): Validation<E, B>
     return switch this {
       case Left(e0):

--- a/src/thx/fp/Dynamics.hx
+++ b/src/thx/fp/Dynamics.hx
@@ -66,37 +66,37 @@ class Dynamics {
       case other: failureNel('Cannot parse a boolean value from $v (type resolved to $other)');
     };
 
-  public static function parseProperty<A>(ob: {}, name: String, f: Dynamic -> VNel<String, A>): VNel<String, A> 
-    return nnNel(ob.getPath(name), 'Property "$name" was not found.').flatMapV(f);
+  public static function parseProperty<E, A>(ob: {}, name: String, f: Dynamic -> VNel<E, A>, err: String -> E): VNel<E, A> 
+    return nnNel(ob.getPath(name), err('Property "$name" was not found.')).flatMapV(f);
 
   // This demands that the parser for the field value be able to accept
   // null values, which is not the usual way of things.
-  public static function parseNullableProperty<A>(ob: {}, name: String, f: Null<Dynamic> -> VNel<String, A>): VNel<String, A> {
+  public static function parseNullableProperty<E, A>(ob: {}, name: String, f: Null<Dynamic> -> VNel<E, A>): VNel<E, A> {
     return f(ob.getPath(name));
   }
 
-  public static function parseOptionalProperty<A>(ob: {}, name: String, f: Dynamic -> VNel<String, A>): VNel<String, Option<A>> {
+  public static function parseOptionalProperty<E, A>(ob: {}, name: String, f: Dynamic -> VNel<E, A>): VNel<E, Option<A>> {
     var property = ob.getPath(name);
     return if (property != null) f(property).map(function(a) return Some(a)) else successNel(None);
   }
 
-  public static function parseArray<A>(v: Dynamic, f: Dynamic -> VNel<String, A>): VNel<String, Array<A>>
+  public static function parseArray<E, A>(v: Dynamic, f: Dynamic -> VNel<E, A>, err: String -> E): VNel<E, Array<A>>
     return switch Type.typeof(v) {
       case TClass(name) :
         switch Type.getClassName(Type.getClass(v)) {
           case "Array": (v: Array<Dynamic>).traverseValidation(f, Nel.semigroup());
-          case other: failureNel('$v is not array-valued (type resolved to $other)');
+          case other: failureNel(err('$v is not array-valued (type resolved to $other)'));
         };
-      case other: failureNel('$v is not array-valued (type resolved to $other)');
+      case other: failureNel(err('$v is not array-valued (type resolved to $other)'));
     };
 
-  public static function parseArrayIndexed<A>(v: Dynamic, f: Dynamic -> Int -> VNel<String, A>): VNel<String, Array<A>>
+  public static function parseArrayIndexed<E, A>(v: Dynamic, f: Dynamic -> Int -> VNel<E, A>, err: String -> E): VNel<E, Array<A>>
     return switch Type.typeof(v) {
       case TClass(name) :
         switch Type.getClassName(Type.getClass(v)) {
           case "Array": (v: Array<Dynamic>).traverseValidationIndexed(f, Nel.semigroup());
-          case other: failureNel('$v is not array-valued (type resolved to $other)');
+          case other: failureNel(err('$v is not array-valued (type resolved to $other)'));
         };
-      case other: failureNel('$v is not array-valued (type resolved to $other)');
+      case other: failureNel(err('$v is not array-valued (type resolved to $other)'));
     };
 }

--- a/src/thx/fp/List.hx
+++ b/src/thx/fp/List.hx
@@ -26,7 +26,7 @@ abstract List<A>(ListImpl<A>) from ListImpl<A> to ListImpl<A> {
 
   public function foldMap<B>(f: A -> B, m: Monoid<B>): B
     return map(f).foldLeft(m.zero, m.append);
-    
+
   public function flatMap<B>(f : A -> List<B>) : List<B>
     return switch this {
       case Nil: Nil;

--- a/src/thx/fp/List.hx
+++ b/src/thx/fp/List.hx
@@ -1,5 +1,6 @@
 package thx.fp;
 
+import thx.Monoid;
 using thx.Arrays;
 using thx.Functions;
 
@@ -23,6 +24,9 @@ abstract List<A>(ListImpl<A>) from ListImpl<A> to ListImpl<A> {
       case Cons(x, xs): xs.foldLeft(f(b, x), f);
     }
 
+  public function foldMap<B>(f: A -> B, m: Monoid<B>): B
+    return map(f).foldLeft(m.zero, m.append);
+    
   public function flatMap<B>(f : A -> List<B>) : List<B>
     return switch this {
       case Nil: Nil;


### PR DESCRIPTION
These are correct structure-preserving mappings which return `Iterator<B>` and `Iterable<B>` rather than Array<B>. These permit fusion of multiple `fmap` operations, which thereby do not create intermediate data structures.