### PR TITLE
Add consistent null-safe methods to Iterables/Iterators

### DIFF
--- a/src/thx/Arrays.hx
+++ b/src/thx/Arrays.hx
@@ -55,11 +55,19 @@ Finds the first occurrance of `element` and returns all the elements after it.
   inline public static function after<T>(array : ReadonlyArray<T>, element : T)
     return array.slice(array.indexOf(element)+1);
 
-  /**
-   * Safe indexed access to array elements.
-   */
+/**
+Safe indexed access to array elements. Deprecated in favor of `getOption`.
+**/
+  @:deprecated("atIndex is deprecated, use getOption instead")
   public static function atIndex<T>(array : ReadonlyArray<T>, i: Int): Option<T>
     return if (i >= 0 && i < array.length) Some(array[i]) else None;
+
+/**
+Safe indexed access to array elements.
+Null values within `array` will also return `None` instead of `Some(null)`.
+**/
+  public static function getOption<T>(array : ReadonlyArray<T>, i : Int) : Option<T>
+    return Options.ofValue(array[i]);
 
 /**
 Applies a side-effect function to all elements in the array.
@@ -957,13 +965,13 @@ Pairs the elements of five arrays in an array of `Tuple5`.
   /**
    * Zip two arrays by applying the provided function to the aligned members.
    */
-  public static function zip2Ap<A, B, C>(f: A -> B -> C, ax: ReadonlyArray<A>, bx: ReadonlyArray<B>): Array<C> 
+  public static function zip2Ap<A, B, C>(f: A -> B -> C, ax: ReadonlyArray<A>, bx: ReadonlyArray<B>): Array<C>
     return zipAp(bx, ax.map(Functions2.curry(f)));
 
   /**
    * Zip three arrays by applying the provided function to the aligned members.
    */
-  public static function zip3Ap<A, B, C, D>(f: A -> B -> C -> D, ax: ReadonlyArray<A>, bx: ReadonlyArray<B>, cx: ReadonlyArray<C>): Array<D> 
+  public static function zip3Ap<A, B, C, D>(f: A -> B -> C -> D, ax: ReadonlyArray<A>, bx: ReadonlyArray<B>, cx: ReadonlyArray<C>): Array<D>
     return zipAp(cx, zip2Ap(Functions3.curry(f), ax, bx));
 
   /**
@@ -1006,13 +1014,13 @@ Returns a copy of the array with the new element inserted at position `pos`.
 Finds the min element of the array given the specified ordering.
 **/
   public static function maxBy<A>(arr: ReadonlyArray<A>, ord: Ord<A>): Option<A>
-    return arr.length == 0 ? None : Some(reduce(arr, ord.max, arr[0])); 
+    return arr.length == 0 ? None : Some(reduce(arr, ord.max, arr[0]));
 
 /**
 Finds the min element of the array given the specified ordering.
 **/
   public static function minBy<A>(arr: ReadonlyArray<A>, ord: Ord<A>): Option<A>
-    return arr.length == 0 ? None : Some(reduce(arr, ord.min, arr[0])); 
+    return arr.length == 0 ? None : Some(reduce(arr, ord.min, arr[0]));
 
   /**
    * Convert an array of tuples to a map. If there are collisions between keys,

--- a/src/thx/Iterables.hx
+++ b/src/thx/Iterables.hx
@@ -56,6 +56,12 @@ Refer to `thx.Arrays.find`.
     return Iterators.find(it.iterator(), predicate);
 
 /**
+Refer to `thx.Arrays.findOption`.
+**/
+  inline public static function findOption<T, TFind>(it : Iterable<T>, predicate : T -> Bool) : Option<T>
+    return Options.ofValue(find(it, predicate));
+
+/**
 Refer to `thx.Arrays.first`.
 **/
   inline public static function first<T, TFind>(it : Iterable<T>) : Null<T>
@@ -66,6 +72,12 @@ Get the element at the `index` position.
 **/
   inline public static function get<T>(it : Iterable<T>, index : Int) : Null<T>
     return Iterators.get(it.iterator(), index);
+
+/**
+Refer to `thx.Arrays.getOption`.
+**/
+  inline public static function getOption<T>(it : Iterable<T>, index : Int) : Option<T>
+    return Options.ofValue(get(it, index));
 
 /**
 Refer to `thx.Arrays.last`.

--- a/src/thx/Iterators.hx
+++ b/src/thx/Iterators.hx
@@ -1,5 +1,6 @@
 package thx;
 
+import haxe.ds.Option;
 import thx.Functions.Functions in F;
 import thx.Tuple;
 #if macro
@@ -68,6 +69,12 @@ Get the element at the `index` position.
   }
 
 /**
+Refer to `thx.Arrays.getOption`
+**/
+  public static function getOption<T>(it : Iterator<T>, index : Int) : Option<T>
+    return Options.ofValue(get(it, index));
+
+/**
 Refer to `thx.Arrays.eachPair`.
 **/
   public static function eachPair<TIn, TOut>(it : Iterator<TIn>, handler : TIn -> TIn -> Bool)
@@ -92,6 +99,12 @@ Refer to `thx.Arrays.find`.
         return element;
     return null;
   }
+
+/**
+Refer to `thx.Arrays.findOption`.
+**/
+  public static function findOption<T, TFind>(it : Iterator<T>, f : T -> Bool) : Option<T>
+    return Options.ofValue(find(it, f));
 
 /**
 Refer to `thx.Arrays.first`.
@@ -169,7 +182,7 @@ Refer to `Array.map`.
    * Produce a new Iterator that lazily applies the provided function to
    * each element of this iterator.
    */
-  public static function fmap<T, S>(it : Iterator<T>, f : T -> S) : Iterator<S> 
+  public static function fmap<T, S>(it : Iterator<T>, f : T -> S) : Iterator<S>
     return new MapIterator(it, f);
 
 /**
@@ -188,7 +201,7 @@ Refer to `thx.Arrays.mapi`.
    * each element of this iterator and an index value that increases with
    * each application.
    */
-  public static function fmapi<T, S>(it : Iterator<T>, f : T -> Int -> S) : Iterator<S> 
+  public static function fmapi<T, S>(it : Iterator<T>, f : T -> Int -> S) : Iterator<S>
     return new MapIIterator(it, f);
 
 /**
@@ -225,7 +238,7 @@ Refer to `thx.Arrays.reducei`.
   /**
    * Fold by mapping the contained values into some monoidal type and reducing with that monoid.
    */
-  public static function foldMap<A, B>(it: Iterator<A>, f: A -> B, m: Monoid<B>): B 
+  public static function foldMap<A, B>(it: Iterator<A>, f: A -> B, m: Monoid<B>): B
     return foldLeft(fmap(it, f), m.zero, m.append);
 
 /**


### PR DESCRIPTION
- deprecated `atIndex` in `Arrays` in favor of the new `getOption` (for name consistency with maps, ordered maps, iterators, etc)
- Array's `getOption` now returns `None` if the value at the key is `null` (instead of `Some(null)`, which `atIndex` returned). This makes it consistent with the `Map` version of `getOption`.
- Iterators and Iterables now also have null-safe friends for `get` and `find`