### PR TITLE
Remove incorrect @:from with extra parameter

### DIFF
--- a/src/thx/BitMatrix.hx
+++ b/src/thx/BitMatrix.hx
@@ -36,7 +36,6 @@ abstract BitMatrix(Array<BitSet>) from Array<BitSet> {
     return fromBitSets(bitSets);
   }
 
-  @:from
   public static function fromString(input : String, ?delimiter : String = ",") : BitMatrix {
     var bitSetStrings = input.split(delimiter);
     var bitSets = bitSetStrings.map(BitSet.fromString);


### PR DESCRIPTION
This was failing in a dox build, but apparently not for a js compile.