### PR TITLE
Add array and string ordered map methods

### DIFF
--- a/src/thx/Arrays.hx
+++ b/src/thx/Arrays.hx
@@ -460,6 +460,13 @@ It returns the first element of the array or null if the array is empty.
   inline public static function first<T>(array : ReadonlyArray<T>) : Null<T>
     return array[0];
 
+
+/**
+It returns an option of the first element or None if the array is empty.
+**/
+  inline public static function firstOption<T>(array : ReadonlyArray<T>) : Option<T>
+    return Options.ofValue(array[0]);
+
 /**
 It traverses an array of elements. Each element is split using the `callback` function and a 'flattened' array is returned.
 

--- a/src/thx/Arrays.hx
+++ b/src/thx/Arrays.hx
@@ -625,6 +625,12 @@ It returns the last element of the array or null if the array is empty.
     return array[array.length-1];
 
 /**
+It returns an option of the last element, `None` if the array is empty.
+**/
+  inline public static function lastOption<T>(array : ReadonlyArray<T>) : Option<T>
+    return Options.ofValue(last(array));
+
+/**
 Static wrapper for `Array` `map` function.
 **/
   #if js inline #end

--- a/src/thx/OrderedMap.hx
+++ b/src/thx/OrderedMap.hx
@@ -76,6 +76,18 @@ class StringOrderedMap<V> extends OrderedMapImpl<String, V> {
 
   override public function empty() : OrderedMapImpl<String, V>
     return new StringOrderedMap();
+
+  static function reduceArray<T, V>(array : ReadonlyArray<T>, toKey : T -> String, toVal : T -> V) : StringOrderedMap<V>
+    return Arrays.reduce(array, function (acc : StringOrderedMap<V>, curr : T) {
+      acc.set(toKey(curr), toVal(curr));
+      return acc;
+    }, new StringOrderedMap());
+
+  public static inline function fromArray<V>(array : ReadonlyArray<V>, toKey : V -> String) : StringOrderedMap<V>
+    return reduceArray(array, toKey, function (val) return val);
+
+  public static inline function fromTuples<V>(array : ReadonlyArray<Tuple<String, V>>) : StringOrderedMap<V>
+    return reduceArray(array, function (t) return t.left, function (t) return t.right);
 }
 
 class OrderedMapImpl<K, V> implements IMap<K, V> {


### PR DESCRIPTION
- Add null-safe `Arrays.lastOption` to get the last item in an array
- Construct StringOrderedMap from an array (by providing a `toKey` function that returns a string)
- Construct StringOrderedMap from a tuple of <String, Value>

I didn't add `Arrays.firstOption` because `Arrays.getOption(0)` is so easy, but maybe it should be there for completeness. Also, does my choice of inlining in `OrderedMap.hx` make sense?