### PR TITLE
Fixes "recursive operator method" compiler error with Int64s

### DIFF
--- a/src/thx/Int64s.hx
+++ b/src/thx/Int64s.hx
@@ -44,15 +44,10 @@ class Int64s {
   public static var minValue = haxe.Int64.make(0x80000000,0x00000001);
 
   public static function abs(value : Int64)
-    return value < zero ? -value : value;
+    return compare(value, Int64.ofInt(0)) > 0 ? value : -value;
 
   public static function compare(a : Int64, b : Int64)
-    if(a > b)
-      return 1;
-    else if(a < b)
-      return -1;
-    else
-      return 0;
+    return haxe.Int64.compare(a, b);
 
   public static function parse(s : String) : Int64 {
     var sIsNegative = false,

--- a/test/thx/TestInt64s.hx
+++ b/test/thx/TestInt64s.hx
@@ -42,5 +42,22 @@ class TestInt64s {
     }
   }
 
+  public function testAbs() {
+    Assert.same(Int64.ofInt(0), Int64s.abs(Int64.ofInt(0)));
+    Assert.same(Int64.ofInt(1), Int64s.abs(Int64.ofInt(1)));
+    Assert.same(Int64.ofInt(1), Int64s.abs(Int64.ofInt(-1)));
+    Assert.same(Int64.ofInt(42), Int64s.abs(Int64.ofInt(42)));
+    Assert.same(Int64.ofInt(42), Int64s.abs(Int64.ofInt(-42)));
+  }
+
+  public function testCompare() {
+    Assert.same(0, Int64s.compare(Int64.ofInt(3), Int64.ofInt(3)));
+    Assert.same(1, Int64s.compare(Int64.ofInt(4), Int64.ofInt(3)));
+    Assert.same(-1, Int64s.compare(Int64.ofInt(4), Int64.ofInt(5)));
+    Assert.same(0, Int64s.compare(Int64.ofInt(-3), Int64.ofInt(-3)));
+    Assert.same(-1, Int64s.compare(Int64.ofInt(-4), Int64.ofInt(-3)));
+    Assert.same(1, Int64s.compare(Int64.ofInt(-4), Int64.ofInt(-5)));
+  }
+
   static inline function here(?pos : haxe.PosInfos) return pos;
 }


### PR DESCRIPTION
I sometimes get a haxe compiler error about "recursive operator method" comparing
haxe.__Int64.__Int64.  I'm not exactly sure how to reproduce it, but this fixes it
for me.