### PR TITLE
Merge method refactoring

### DIFF
--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -93,21 +93,33 @@ public static function inflate(o: {}) {
 }
 
 /**
-Merges `first` and `second` using the `combine` strategy to return a merged object. The returned
-object is typed as an object containing all of the fields from both `first` and `second`.
+Shallow, typed merge of two anonymous objects.
 **/
+  //@:deprecated('use thx.Objects.shallowMerge or thx.Objects.deepMerge instead')
   macro public static function merge(first : ExprOf<{}>, second : ExprOf<{}>) {
-    return thx.macro.Objects.mergeImpl(first, second);
+    haxe.macro.Context.warning('use thx.Objects.shallowMerge or thx.Objects.deepMerge instead', haxe.macro.Context.currentPos());
+    return thx.macro.Objects.shallowMergeImpl(first, second);
   }
 
 /**
-Copies the values from the fields of `first` and `second` to a new object. If `first` and `second` contain
-fields with the same name, the returned object will use the fields from `second`. Both objects passed
-to this function will be unmodified.
-
-The `combine` operation is not recursive and does a shallow merge of the two objects.
+Shallow, typed merge of two anonymous objects.
 **/
+  macro public static function shallowMerge(first: ExprOf<{}>, second: ExprOf<{}>) {
+    return thx.macro.Objects.shallowMergeImpl(first, second);
+  }
+
+/**
+Shallow, untyped merge of two objects.
+**/
+  @:deprecated('use thx.Objects.shallowCombine or thx.Objects.deepCombine instead')
   public static function combine(first : {}, second : {}) : {} {
+    return shallowCombine(first, second);
+  }
+
+/**
+Shallow, untyped merge of two objects.
+**/
+  public static function shallowCombine(first: {}, second: {}) : {} {
     var to = {};
     for(field in Reflect.fields(first)) {
       Reflect.setField(to, field, Reflect.field(first, field));
@@ -116,6 +128,27 @@ The `combine` operation is not recursive and does a shallow merge of the two obj
       Reflect.setField(to, field, Reflect.field(second, field));
     }
     return to;
+  }
+
+/**
+Deep merge of two objects.  If types of first or second are specified at compile time, the
+resulting object will be typed appropriately.
+**/
+  /* TODO: placeholder for future macro-based deepMergeImpl
+  macro public static function deepMerge(first: ExprOf<{}>, second: ExprOf<{}>) {
+    return thx.macro.Objects.deepMergeImpl(first, second);
+  }
+  */
+
+/**
+Deep, untyped merge of two objects.
+**/
+  public static function deepCombine(first: {}, second: {}) : {} {
+    var deflatedSecond = Objects.deflate(second);
+    for (keyPath in Reflect.fields(deflatedSecond)) {
+      setPath(first, keyPath, Reflect.field(deflatedSecond, keyPath));
+    }
+    return first;
   }
 
 /**

--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -109,7 +109,7 @@ Shallow, typed merge of two anonymous objects.
   }
 
 /**
-Shallow, untyped merge of two objects.
+Shallow, untyped merge of two anonymous objects.
 **/
   @:deprecated('use thx.Objects.shallowCombine or thx.Objects.deepCombine instead')
   public static function combine(first : {}, second : {}) : {} {
@@ -117,7 +117,7 @@ Shallow, untyped merge of two objects.
   }
 
 /**
-Shallow, untyped merge of two objects.
+Shallow, untyped merge of two anonymous objects.
 **/
   public static function shallowCombine(first: {}, second: {}) : {} {
     var to = {};
@@ -131,8 +131,7 @@ Shallow, untyped merge of two objects.
   }
 
 /**
-Deep merge of two objects.  If types of first or second are specified at compile time, the
-resulting object will be typed appropriately.
+Deep, typed merge of two objects.
 **/
   /* TODO: placeholder for future macro-based deepMergeImpl
   macro public static function deepMerge(first: ExprOf<{}>, second: ExprOf<{}>) {

--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -95,9 +95,8 @@ public static function inflate(o: {}) {
 /**
 Shallow, typed merge of two anonymous objects.
 **/
-  //@:deprecated('use thx.Objects.shallowMerge or thx.Objects.deepMerge instead')
   macro public static function merge(first : ExprOf<{}>, second : ExprOf<{}>) {
-    haxe.macro.Context.warning('use thx.Objects.shallowMerge or thx.Objects.deepMerge instead', haxe.macro.Context.currentPos());
+    haxe.macro.Context.warning('use thx.Objects.shallowMerge or thx.Objects.deepMerge instead', haxe.macro.Context.currentPos()); // macro-time @:deprecation
     return thx.macro.Objects.shallowMergeImpl(first, second);
   }
 

--- a/src/thx/macro/Objects.hx
+++ b/src/thx/macro/Objects.hx
@@ -32,7 +32,7 @@ class Objects {
     return TypeTools.toComplexType(TypeTools.follow(Context.getType(qn)));
   }
 
-  public static function mergeImpl(to : ExprOf<{}>, from : ExprOf<{}>) {
+  public static function shallowMergeImpl(to : ExprOf<{}>, from : ExprOf<{}>) {
     var typeTo = TypeTools.toComplexType(Context.typeof(to));
     var typeFrom = TypeTools.toComplexType(Context.typeof(from));
     var arr = [];
@@ -70,11 +70,13 @@ class Objects {
     }
 
     var t : ComplexType = TAnonymous(arr);
-    return macro (cast thx.Objects.combine($e{to}, $e{from}) : $t);
+    return macro (cast thx.Objects.shallowCombine($e{to}, $e{from}) : $t);
   }
   #end
 
-  macro public static function merge(to : ExprOf<{}>, from : ExprOf<{}>) {
-    return mergeImpl(to, from);
+  macro public static function shallowMerge(to : ExprOf<{}>, from : ExprOf<{}>) {
+    return shallowMergeImpl(to, from);
   }
+
+  // TODO: macro-time deepMergeImpl/deepMerge (with properly-typed result)
 }

--- a/test/thx/TestObjects.hx
+++ b/test/thx/TestObjects.hx
@@ -61,9 +61,9 @@ class TestObjects {
     }
   }
 
-  public function testCombine() {
+  public function testShallowCombine() {
     var o = {'name' : 'Franco', age : 19};
-    var out : Dynamic = thx.Objects.combine(o, { 'foo': 'bar', 'name' : 'Michael', 'age' : 'Two'});
+    var out : Dynamic = thx.Objects.shallowCombine(o, { 'foo': 'bar', 'name' : 'Michael', 'age' : 'Two'});
 
     Assert.same("Michael", out.name);
     Assert.same("Two", out.age);
@@ -71,11 +71,11 @@ class TestObjects {
     Assert.same("Franco", o.name);
   }
 
-  public function testMergeWithNullable() {
+  public function testShallowMergeWithNullable() {
     var a : Null<SpecialObject>,
         options : { sub : Null<SpecialObject> } = { sub : {}};
 
-    a = Objects.merge({
+    a = Objects.shallowMerge({
       foo : 'baz',
       bar : 'qux'
     }, options.sub);
@@ -83,7 +83,7 @@ class TestObjects {
     Assert.same('baz', a.foo);
   }
 
-  public function testMergeWithTypedef() {
+  public function testShallowMergeWithTypedef() {
     var to : SpecialObject = {
           bar : "qux"
         },
@@ -92,11 +92,59 @@ class TestObjects {
           extra : "field"
         };
 
-    var merged : SpecialObject = thx.Objects.merge(to, from);
+    var merged : SpecialObject = thx.Objects.shallowMerge(to, from);
 
     Assert.same(merged.foo, from.foo);
     Assert.same(merged.bar, to.bar);
     Assert.same(Reflect.field(merged, 'extra'), 'field');
+  }
+
+  public function testDeepMerge() {
+    var first = {
+      a: {
+        a1: 123,
+        a2: [1, 2, 3],
+      },
+      b: {
+        b1: 456,
+        b2: [4, 5, 6]
+      }
+    };
+    var second = {
+      a: {
+        a3: "aaa"
+      },
+      b: {
+        b1: 999,
+        b2: [10, 20, 30],
+        b3: {
+          b4: "bbb"
+        }
+      },
+      c: {
+        c1: 789,
+        c2: [789]
+      },
+    };
+    var expected = {
+      a: {
+        a1: 123,
+        a2: [1, 2, 3],
+        a3: "aaa"
+      },
+      b: {
+        b1: 999,
+        b2: [10, 20, 30],
+        b3: {
+          b4: "bbb"
+        }
+      },
+      c: {
+        c1: 789,
+        c2: [789]
+      },
+    };
+    Assert.same(expected, thx.Objects.deepCombine(first, second));
   }
 
   public function testHasPath() {


### PR DESCRIPTION
- Deprecate `thx.Objects.merge` and `combine` in favor of `shallowMerge` and `shallowCombine`
- Add `deepCombine` method that does a recursive (deep) merge of two objects
- TODO: I did not implement the macro-time `deepMerge`, because I just needed the untyped `deepCombine` at this time.  Macro-time `deepMerge` will look like thx.macro.Objects.shallowMergeImpl`, but needs to go deep recursively.