### PR TITLE
Add error-polymorphic versions of dynamics primitive parsing functions.

### DIFF
--- a/src/thx/fp/Dynamics.hx
+++ b/src/thx/fp/Dynamics.hx
@@ -10,6 +10,7 @@ import thx.Either;
 import thx.Eithers.toVNel;
 import thx.Ints;
 import thx.Floats;
+import thx.Functions.identity;
 import thx.Options;
 import thx.Monoid;
 import thx.Nel;
@@ -28,58 +29,73 @@ using thx.Options;
 using thx.Objects;
 
 class Dynamics {
-  public static function parseInt(v: Dynamic): VNel<String, Int>
+  inline public static function parseInt(v: Dynamic): VNel<String, Int>
+    return parseInt0(v, identity);
+
+  public static function parseInt0<E>(v: Dynamic, err: String -> E): VNel<E, Int>
     return switch Type.typeof(v) {
       case TInt :   successNel(cast v);
       case TClass(name) :
         switch Type.getClassName(Type.getClass(v)) {
           case "String" if (Ints.canParse(v)) : successNel(Ints.parse(cast v));
-          case other: failureNel('Cannot parse an integer value from $v (type resolved to $other)');
+          case other: failureNel(err('Cannot parse an integer value from $v (type resolved to $other)'));
         };
 
-      case other: failureNel('Cannot parse an integer value from $v (type resolved to $other)');
+      case other: failureNel(err('Cannot parse an integer value from $v (type resolved to $other)'));
     };
 
-  public static function parseFloat(v: Dynamic): VNel<String, Float>
+  inline public static function parseFloat(v: Dynamic): VNel<String, Float>
+    return parseFloat0(v, identity);
+
+  public static function parseFloat0<E>(v: Dynamic, err: String -> E): VNel<E, Float>
     return switch Type.typeof(v) {
       case TInt :   successNel(cast v);
       case TFloat : successNel(cast v);
       case TClass(name) :
         switch Type.getClassName(Type.getClass(v)) {
           case "String" if (Floats.canParse(v)) : successNel(Floats.parse(cast v));
-          case other: failureNel('Cannot parse a floating-point value from $v (type resolved to $other)');
+          case other: failureNel(err('Cannot parse a floating-point value from $v (type resolved to $other)'));
         };
-      case other: failureNel('Cannot parse a floating-point value from $v (type resolved to $other)');
+      case other: failureNel(err('Cannot parse a floating-point value from $v (type resolved to $other)'));
     };
 
-  public static function parseString(v: Dynamic): VNel<String, String>
+  inline public static function parseString(v: Dynamic): VNel<String, String>
+    return parseString0(v, identity);
+
+  public static function parseString0<E>(v: Dynamic, err: String -> E): VNel<E, String>
     return switch Type.typeof(v) {
       case TClass(name) :
         switch Type.getClassName(Type.getClass(v)) {
           case "String": successNel(cast v);
-          case other: failureNel('$v is not a String value (type resolved to $other)');
+          case other: failureNel(err('$v is not a String value (type resolved to $other)'));
         };
-      case other: failureNel('$v is not a String value (type resolved to $other)');
+      case other: failureNel(err('$v is not a String value (type resolved to $other)'));
     };
 
-  public static function parseNonEmptyString(v : Dynamic) : VNel<String, String>
-    return parseString(v).flatMapV(function(str : String) : VNel<String, String> {
-      return if (str == null || str.length == 0) {
-        failureNel('"$v" is not a non-empty String value');
+  inline public static function parseNonEmptyString(v : Dynamic) : VNel<String, String>
+    return parseNonEmptyString0(v, identity);
+
+  public static function parseNonEmptyString0<E>(v : Dynamic, err: String -> E) : VNel<E, String>
+    return parseString0(v, err).flatMapV(
+      function(str : String) return if (str == null || str.length == 0) {
+        failureNel(err('"$v" is not a non-empty String value'));
       } else {
         successNel(str);
       }
-    });
+    );
 
-  public static function parseBool(v: Dynamic): VNel<String, Bool>
+  inline public static function parseBool(v: Dynamic): VNel<String, Bool>
+    return parseBool0(v, identity);
+
+  public static function parseBool0<E>(v: Dynamic, err: String -> E): VNel<E, Bool>
     return switch Type.typeof(v) {
       case TBool: successNel(cast v);
       case TClass(name) :
         switch Type.getClassName(Type.getClass(v)) {
           case "String" if (Bools.canParse(v)) : successNel(Bools.parse(cast v));
-          case other: failureNel('Cannot parse a boolean value from $v (type resolved to $other)');
+          case other: failureNel(err('Cannot parse a boolean value from $v (type resolved to $other)'));
         };
-      case other: failureNel('Cannot parse a boolean value from $v (type resolved to $other)');
+      case other: failureNel(err('Cannot parse a boolean value from $v (type resolved to $other)'));
     };
 
   public static function parseDate(v: Dynamic): VNel<String, Date>


### PR DESCRIPTION
When writing `parseProperty("foo", parseString, someFunction)`
it's often the case that you don't want to use 'identity' for
someFunction, but the current design allows only 'identity' in
this situation.