### PR TITLE
Add thx.fp.Dynamics.parsePlainObject

### DIFF
--- a/build-completion.hxml
+++ b/build-completion.hxml
@@ -1,0 +1,6 @@
+-cp src
+-cp test
+-lib utest
+-main TestAll
+-js _
+--no-output

--- a/src/thx/fp/Dynamics.hx
+++ b/src/thx/fp/Dynamics.hx
@@ -113,6 +113,14 @@ class Dynamics {
   public static function parseLocalYearMonth(v: Dynamic): VNel<String, LocalYearMonth>
     return parseString(v).flatMapV(toVNel.compose(LocalYearMonth.parse));
 
+  public static function parsePlainObject(v: Dynamic) : VNel<String, {}> {
+    return if (thx.Types.isAnonymousObject(v)) {
+      successNel(cast v);
+    } else {
+      failureNel('$v is not a plain object');
+    }
+  }
+
   public static function parseOptional<E, A>(v: Null<Dynamic>, f: Dynamic -> VNel<E, A>) : VNel<E, Option<A>> {
     return if (v != null) f(v).map(Some) else successNel(None);
   }

--- a/test/thx/TestLocalMonthDay.hx
+++ b/test/thx/TestLocalMonthDay.hx
@@ -60,19 +60,19 @@ class TestLocalMonthDay {
   }
 
   public function testFromString() {
+    Assert.same(LocalMonthDay.create(1, 1), LocalMonthDay.fromString("--00-00"));
+    Assert.same(LocalMonthDay.create(2, 29), LocalMonthDay.fromString("--02-30"));
     Assert.raises(function() LocalMonthDay.fromString("x"));
-    Assert.raises(function() LocalMonthDay.fromString("--00-00"));
     Assert.raises(function() LocalMonthDay.fromString("--x-01"));
     Assert.raises(function() LocalMonthDay.fromString("--01-xx"));
-    Assert.raises(function() LocalMonthDay.fromString("--02-30"));
   }
 
   public function testParse() {
-    Assert.isTrue(LocalMonthDay.parse("x").isLeft());
     Assert.same(Right(LocalMonthDay.create(1, 1)), LocalMonthDay.parse("--00-00"));
+    Assert.same(Right(LocalMonthDay.create(2, 29)), LocalMonthDay.parse("--02-30"));
+    Assert.isTrue(LocalMonthDay.parse("x").isLeft());
     Assert.isTrue(LocalMonthDay.parse("--x-01").isLeft());
     Assert.isTrue(LocalMonthDay.parse("--01-xx").isLeft());
-    Assert.same(Right(LocalMonthDay.create(2, 29)), LocalMonthDay.parse("--02-30"));
   }
 
   public function testEquals() {

--- a/test/thx/fp/TestDynamics.hx
+++ b/test/thx/fp/TestDynamics.hx
@@ -53,7 +53,9 @@ class TestDynamics {
     Assert.same(Left(Single("hi is not a plain object")), parsePlainObject("hi"));
     Assert.same(Left(Single("[] is not a plain object")), parsePlainObject([]));
     Assert.same(Left(Single("true is not a plain object")), parsePlainObject(true));
+#if js
     Assert.same(Left(Single("Error: message is not a plain object")), parsePlainObject(new js.Error('message')));
+#end
   }
 
   public function testParseOptional() {

--- a/test/thx/fp/TestDynamics.hx
+++ b/test/thx/fp/TestDynamics.hx
@@ -9,10 +9,11 @@ import thx.Either;
 using thx.Eithers;
 import thx.Functions.*;
 using thx.Options;
-import thx.fp.Dynamics.*;
+import thx.Nel;
 import thx.Tuple;
 import thx.Validation;
 import thx.Validation.VNel;
+import thx.fp.Dynamics.*;
 
 import utest.Assert;
 
@@ -43,6 +44,16 @@ class TestDynamics {
     Assert.isTrue(thx.fp.Dynamics.parseNonEmptyString(true).either.isLeft());
     Assert.isTrue(thx.fp.Dynamics.parseNonEmptyString({}).either.isLeft());
     Assert.isTrue(thx.fp.Dynamics.parseNonEmptyString([]).either.isLeft());
+  }
+
+  public function testParsePlainObject() {
+    Assert.same(Right({ }), parsePlainObject({ }));
+    Assert.same(Right({ a: "b" }), parsePlainObject({ a: "b" }));
+    Assert.same(Left(Single("null is not a plain object")), parsePlainObject(null));
+    Assert.same(Left(Single("hi is not a plain object")), parsePlainObject("hi"));
+    Assert.same(Left(Single("[] is not a plain object")), parsePlainObject([]));
+    Assert.same(Left(Single("true is not a plain object")), parsePlainObject(true));
+    Assert.same(Left(Single("Error: message is not a plain object")), parsePlainObject(new js.Error('message')));
   }
 
   public function testParseOptional() {


### PR DESCRIPTION
Helper function to parse a Dynamic into a {}.

Also fix the TestLocalMonthDay tests that are failing in the build.