### PR TITLE
Rename thx.Functions.lift to "passTo"

### DIFF
--- a/src/thx/Functions.hx
+++ b/src/thx/Functions.hx
@@ -387,21 +387,16 @@ Lambda expressions
     return SlambdaMacro.f(fn, restArgs);
 
 /**
-Converts an instance of type `T` to an instance of type `U`.
-
-Useful as an extension methods for converting a value to another type inside a chain of function calls.
-
-E.g.
-
-```
-using thx.Functions;
-import thx.Options;
-
-var arr: Array<Int> = [1, 2, 3];
-var opt : Option<Array<Int>> = myArray.lift(Options.ofValue);
-Assert.same(Some(arr), opt); // true
-```
+Extension method for function application to an argument with a function.
 **/
-  public static inline function lift<T, U>(t : T, f: T -> U) : U
-    return f(t);
+  public static inline function passTo<A, B>(a : A, f: A -> B) : B {
+    return f(a);
+  }
+
+/**
+Extension method for function application with a function to an argument.
+**/
+  public static inline function applyTo<A, B>(f : A -> B, a : A) : B {
+    return f(a);
+  }
 }

--- a/test/thx/TestFunctions.hx
+++ b/test/thx/TestFunctions.hx
@@ -74,11 +74,17 @@ class TestFunctions {
     Assert.isFalse((function() return true).negate()());
   }
 
-  public function testLift() {
+  public function testPassTo() {
     var arr : Array<Int> = [1, 2, 3];
-    Assert.same(Some(arr), arr.lift(thx.Options.ofValue));
-    Assert.same(Right(arr), arr.lift(Right));
-    Assert.same(Left(arr), arr.lift(Left));
-    Assert.same([1], 1.lift(Arrays.fromItem));
+    Assert.same(Some(arr), arr.passTo(thx.Options.ofValue));
+    Assert.same(Right(arr), arr.passTo(Right));
+    Assert.same(Left(arr), arr.passTo(Left));
+    Assert.same([1], 1.passTo(Arrays.fromItem));
+  }
+
+  public function testApplyTo() {
+    Assert.same(1, thx.Functions.identity.applyTo(1));
+    Assert.same(Some(1), Options.ofValue.applyTo(1));
+    Assert.same(None, Options.ofValue.applyTo(null));
   }
 }


### PR DESCRIPTION
Change `lift` function to a more primitive name, because it's not actually a `lift` in the FP sense.