### PR TITLE
added type hints to returns  from a few anonymous functions

### DIFF
--- a/src/thx/Arrays.hx
+++ b/src/thx/Arrays.hx
@@ -322,7 +322,7 @@ comparison is ==.
 
     for (v in array) {
       var keep = !any(result, function(r) {
-        return predicate(r, v);
+	  return (predicate(r, v) : Bool);
       });
       if (keep) result.push(v);
     }
@@ -779,7 +779,7 @@ trace(indexes); // output [2,0,1]
 **/
   public static function rank<T>(array : ReadonlyArray<T>, compare : T -> T -> Int, ?incrementDuplicates = true) : Array<Int> {
     var arr = Arrays.mapi(array, function(v, i) return Tuple.of(v, i));
-    arr.sort(function(a, b) return compare(a.left, b.left));
+    arr.sort(function(a, b) return (compare(a.left, b.left) : Int));
     if(incrementDuplicates) {
       var usedIndexes = thx.Set.createInt();
       return Arrays.reducei(arr, function(acc, x, i) {

--- a/src/thx/Iterables.hx
+++ b/src/thx/Iterables.hx
@@ -264,7 +264,7 @@ as compared by the specified ordering.
       res.push(e);
     }
     for (e in b.iterator()) {
-      if (!any(res, function (x: T): Bool return eq(x, e)))
+      if (!any(res, function (x: T) return (eq(x, e): Bool)))
         res.push(e);
     }
     return res;
@@ -277,7 +277,7 @@ as compared by the specified ordering.
   public static function differenceBy<T>(a:Iterable<T>, b:Iterable<T>, eq: T -> T -> Bool): Array<T> {
     var res: Array<T> = [];
     for (e in a.iterator()) {
-      if (!any(b, function (x: T): Bool return eq(x, e)))
+      if (!any(b, function (x: T) return (eq(x, e): Bool)))
         res.push(e);
     }
     return res;


### PR DESCRIPTION
In order to get thx.core to compile on the linux (cpp) and android targets I had to alter the way types were indicated in the returns from a few functions.  I opted for the `(thing : Type)` syntax in the return statement.

I see that a change was made about 9 days ago to  `Iterables.unionBy` and `Iterables.differenceBy` to add explicit return types to the anonymous functions.  It seems, however, that the generated cpp was inserting an incorrect cast after the return statement but before the return value, which caused a unification error.  E.g. `return (WrongType) value;` in the cpp.

See issue #248 for the types of errors that were appearing.

I have tested these changes on linux, android, neko, and html5 targets with no compile or runtime errors.

Let me know if this works for you :)