### PR TITLE
make it compile with actual Haxe 4 again

### DIFF
--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -468,7 +468,7 @@ Create a copy of the object with the field `field` replaced by `value`.
 #if macro
   static function buildFromAnonymous(matchField, fields, value, pos) {
     var found = false;
-    var e = haxe.macro.Expr.ExprDef.EObjectDecl(fields.map(function(field)#if ((haxe_ver >= 4.0) && !macro ) :haxe.macro.Expr.ObjectField #end {
+    var e = haxe.macro.Expr.ExprDef.EObjectDecl(fields.map(function(field)#if (haxe_ver >= 4.0) :haxe.macro.Expr.ObjectField #end {
       var fieldName = field.name;
       if(fieldName == matchField) {
         found = true;

--- a/src/thx/OrderedMap.hx
+++ b/src/thx/OrderedMap.hx
@@ -185,6 +185,9 @@ class OrderedMapImpl<K, V> implements IMap<K, V> {
     return arr.map(function (key)
       return new Tuple2(key, map.get(key)));
 
+  public function keyValueIterator ():KeyValueIterator<K, V> 
+    return arr.map((key) -> {key:key, value: map.get(key)}).iterator();
+
   public function toString() : String {
     var s = "";
     s += "[";


### PR DESCRIPTION
- Haxe 4 needs a keyValueIterator() for IMap.
- the additional conditional && !macro caused the conditional #if (haxe_ver >= 4.0) to always fail because the whole block is guarded with #if macro