### PR TITLE
Fix compatibility with Haxe dev

### DIFF
--- a/src/thx/Iterators.hx
+++ b/src/thx/Iterators.hx
@@ -51,9 +51,6 @@ An optional equality function can be passed as the last argument. If not provide
       if(!equality(a.next(), b.next()))
         return false;
     }
-    #if haxe < 3.3
-    return true;
-    #end
   }
 
 /**


### PR DESCRIPTION
I don't think this ever worked:

- Haxe did not used to define `haxe`, this was likely meant to be `haxe_ver`
- The `< 3.3` is not part of the check, since it's not wrapped in parens. It just wasn't an issue so far because `#if haxe` also evaluated to `false`.
- Haxe 4 adds a `haxe` define (https://github.com/HaxeFoundation/haxe/pull/8305), so this block suddenly becomes active.