### PR TITLE
do not commit .haxelib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ doc/dox
 .vscode
 .DS_Store
 *.sublime-*
+.haxelib

--- a/.haxelib/utest/.dev
+++ b/.haxelib/utest/.dev
@@ -1,1 +1,0 @@
-/Users/francoponticelli/projects/thx.core/.haxelib/utest/git/src


### PR DESCRIPTION
I *think* the .haxelib folder was committed by mistake.
It's currently a broken git submodule that prevents checking out the repo correctly.