### PR TITLE
Fix wrong sign in DateTime#subtractDate

### DIFF
--- a/src/thx/DateTime.hx
+++ b/src/thx/DateTime.hx
@@ -540,7 +540,7 @@ abstract DateTime(Array<Int64>) {
 		return new DateTime(DateTimeUtc.fromInt64(utc.ticks - time.ticks), offset);
 
 	@:op(A - B) function subtractDate(date:DateTime):Time {
-		var base = DateTimeUtc.fromInt64(utc.ticks + date.utc.ticks),
+		var base = DateTimeUtc.fromInt64(utc.ticks - date.utc.ticks),
 			date = new DateTime(base, offset);
 		return new Time(date.utc.ticks);
 	}

--- a/test/thx/TestDateTime.hx
+++ b/test/thx/TestDateTime.hx
@@ -189,6 +189,12 @@ class TestDateTime extends utest.Test {
 		Assert.isTrue(DateTime.is([haxe.Int64.ofInt(1), haxe.Int64.ofInt(2)])); // Array of exactly 2 Int64s is considered to be a DateTime
 	}
 
+	public function testSubtract() {
+		var time = Time.createDays(10, 9, 8, 7, 6);
+		var date2 = date + time;
+		Assert.equals(date2 - date, time);
+	}
+
 	public function testParse() {
 		assertParse(DateTime.create(2012, 2, 3, 11, 30, 59, 66, Time.zero), "2012-02-03T11:30:59.066");
 		assertParse(DateTime.create(2012, 2, 3, 11, 30, 59, 66, Time.fromHours(-2)), "2012-02-03T11:30:59.066-02:00");


### PR DESCRIPTION
"+" is used instead of "-" in date subtraction, leading to wrong answer