### PR TITLE
Fix thx.Set#toString type confusion

### DIFF
--- a/src/thx/Set.hx
+++ b/src/thx/Set.hx
@@ -179,7 +179,7 @@ abstract Set<T>(Map<T, Bool>) {
 		Converts `Set` into `String`. To differentiate from normal `Array`s the output string
 		uses curly braces `{}` instead of square brackets `[]`.
 	**/
-	@:to public function toString()
+	@:to public function toString(): String
 		return "{" + toArray().join(", ") + "}";
 
 	function get_length() {


### PR DESCRIPTION
Python target seems to be confused by missing type for `thx.Set#toString`. Atleast in haxe 4.2.4 but these changes should still be compatible with older versions.
```haxe
haxe build_scripts/build_python.hxml
#REDACTED#/.haxelib/thx,core/git/src/thx/Set.hx:183: characters 3-42 : String should be Iterable<thx.Set.T>
#REDACTED#/.haxelib/thx,core/git/src/thx/Set.hx:183: characters 3-42 : ... String has no field iterator
```

You can see it in this example that I prepared for another thx.core-related (but it's probably haxe to blame there) bug: https://github.com/xunto/haxe-stack-overflow-example