### PR TITLE
Add if condition for hl in bigint.Small

### DIFF
--- a/src/thx/bigint/Small.hx
+++ b/src/thx/bigint/Small.hx
@@ -28,7 +28,7 @@ class Small implements BigIntImpl {
 	}
 
 	public function addSmall(small:Small):BigIntImpl {
-		#if (cs || java || cpp || neko || flash || eval)
+		#if (cs || java || cpp || neko || flash || eval || hl)
 		if (Bigs.canAdd(value, small.value))
 		#else
 		if (Bigs.isPrecise(value + small.value))
@@ -85,7 +85,7 @@ class Small implements BigIntImpl {
 		return that.isSmall ? multiplySmall(cast that) : multiplyBig(cast that);
 
 	public function multiplySmall(small:Small):BigIntImpl {
-		#if (cs || java || cpp || neko || flash || eval)
+		#if (cs || java || cpp || neko || flash || eval || hl)
 		if (Bigs.canMultiply(value, small.value))
 		#else
 		if (Bigs.isPrecise(value * small.value))
@@ -172,7 +172,7 @@ class Small implements BigIntImpl {
 	}
 
 	public function square():BigIntImpl {
-		#if (cs || java || cpp || neko || flash || eval)
+		#if (cs || java || cpp || neko || flash || eval || hl)
 		if (Bigs.canMultiply(value, value))
 		#else
 		if (Bigs.isPrecise(value * value))


### PR DESCRIPTION
Git repo provided in https://github.com/HaxeFoundation/hashlink/issues/688 mentioned a bug when using thx.core with HashLink

> `BigInt.fromStringWithBase("12345678912345678912345678909",10);` number is not parsed/initialized properly but as a small number, also multiplying give wrong results

This PR fix it.