### PR TITLE
Make compatiable with cs on haxe 4.3.6

### DIFF
--- a/src/thx/Objects.hx
+++ b/src/thx/Objects.hx
@@ -394,6 +394,12 @@ class Objects {
 
 		E.g. { foo : 'bar' }.removePath('foo') -> returns {}
 	**/
+	#if cs
+	public static macro function removePath(o:{}, path:String):{} {
+		haxe.macro.Context.error("this is not supported in cs", haxe.macro.Context.currentPos());
+		return {};
+	}
+	#else
 	public static function removePath(o:{}, path:String):{} {
 		path = normalizePath(path);
 		var paths = path.split(".");
@@ -422,6 +428,7 @@ class Objects {
 
 		return o;
 	}
+	#end
 
 	static inline function normalizePath(path:String):String {
 		return ~/\[(\d+)\]/g.replace(path, ".$1"); // Normalize [x] array access to .x (where x is an integer)

--- a/src/thx/Strings.hx
+++ b/src/thx/Strings.hx
@@ -543,9 +543,11 @@ class Strings {
 	/**
 		It transforms a string into an `Array` of char codes in integer format.
 	**/
-	inline public static function toCharcodes(s:String):Array<Int>
-		return map(s, // function(s : String) return new UnicodeString(s).charCodeAt(0)
-			function(s:String) return s.charCodeAt(0));
+	inline public static function toCharcodes(s:String):Array<Int>{
+		var ar:Array<String>=s.split("");
+		var ar2:Array<Int>=ar.map(v->v.charCodeAt(0));
+		return ar2;
+	}
 
 	/**
 		Returns an array of `String` whose elements are equally long (using `len`). If the string `s`


### PR DESCRIPTION
thx.core had 2 type issues that prevented to use this library on cs projects.

I fixed 1 of them' the other I just commented out the function body for cs' this means that the function and its deriavitives cannot be used in hxcs I added a trace to avoid confusion.

